### PR TITLE
signal handling & waitpid(2) error

### DIFF
--- a/pam_script.c
+++ b/pam_script.c
@@ -25,7 +25,7 @@
 #include <unistd.h>			/* stat, fork, execve, **environ */
 #include <stdlib.h>			/* calloc, setenv, putenv */
 #include <errno.h>			/* errno */
-#include <signal.h>			/* signal, SIGCHLD, SIG_DFL */
+#include <signal.h>			/* signal, SIGCHLD, SIG_DFL, SIG_ERR */
 
 /* enable these module-types */
 #define PAM_SM_AUTH
@@ -183,7 +183,9 @@ static int pam_script_exec(pam_handle_t *pamh,
 		return retval;
 	}
 
-	signal(SIGCHLD, SIG_DFL);
+	if (signal(SIGCHLD, SIG_DFL) == SIG_ERR)
+		pam_script_syslog(LOG_WARNING,
+			"cannot reset SIGCHLD handler to the default");
 
 	/* Execute external program */
 	/* fork process */

--- a/pam_script.c
+++ b/pam_script.c
@@ -24,6 +24,8 @@
 #include <sys/wait.h>			/* wait */
 #include <unistd.h>			/* stat, fork, execve, **environ */
 #include <stdlib.h>			/* calloc, setenv, putenv */
+#include <errno.h>			/* errno */
+#include <signal.h>			/* signal, SIGCHLD, SIG_DFL */
 
 /* enable these module-types */
 #define PAM_SM_AUTH
@@ -181,6 +183,8 @@ static int pam_script_exec(pam_handle_t *pamh,
 		return retval;
 	}
 
+	signal(SIGCHLD, SIG_DFL);
+
 	/* Execute external program */
 	/* fork process */
 	switch(child_pid = fork()) {
@@ -213,7 +217,11 @@ static int pam_script_exec(pam_handle_t *pamh,
 		return retval;
 
 	default:				/* parent */
-		(void) waitpid(child_pid, &status, 0);
+		if (waitpid(child_pid, &status, 0) == -1) {
+			pam_script_syslog(LOG_ALERT,
+				"error waiting for child %d: %s", child_pid, strerror(errno));
+			return retval;
+		}
 		if (WIFEXITED(status))
 			return (WEXITSTATUS(status) ? rv : PAM_SUCCESS);
 		else


### PR DESCRIPTION
SIGCHLD might be caught (or being explicitly ignored) in the calling process instead of pam-script itself, thus lead to waitpid(2) error ("No child processes").

This patch
* restores the default handler for SIGCHLD before the fork() call
* logs waitpid(2) error, so others won't be clueless

Cheers.