### PR TITLE
Remove bashism in etc/pam_script

### DIFF
--- a/etc/pam_script
+++ b/etc/pam_script
@@ -29,7 +29,7 @@ goodperms () {
 
 	owner=`echo $stat_output | /usr/bin/cut -d ':' -f 2`
 	group=`echo $stat_output | /usr/bin/cut -d ':' -f 3`
-	world_write_bit=${stat_output:8:1}
+	world_write_bit=`echo $stat_output | /usr/bin/cut -c 9`
 
 	if [ ${world_write_bit} != "-" -o "$owner" -ne 0 -o "$group" -ne 0 ]; then
 		echo "$0: Unsafe permissions for path $path; Rejecting execution." 1>&2


### PR DESCRIPTION
${foo:n:m} is bash-specific, so fails when /bin/sh is e.g. dash, as is usual
on Debian/Ubuntu systems. The script already assumes /usr/bin/cut available
so lets use that to extract world_write_bit from stat_output